### PR TITLE
feat: 감정 통계 API 추가 및 다이어리 수정

### DIFF
--- a/app/ai/schema.py
+++ b/app/ai/schema.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from app.diary.model import MainEmotion
+from app.diary.model import MainEmotionType
 
 
 class PeriodType(str, Enum):
@@ -30,7 +30,7 @@ class EmotionAnalysis(BaseModel):
 class DiaryEmotionResponse(BaseModel):
     """일기 감정 분석 응답"""
 
-    main_emotion: MainEmotion = Field(..., description="주요 감정")
+    main_emotion: MainEmotionType = Field(..., description="주요 감정")
     confidence: float = Field(..., description="분석 신뢰도", ge=0, le=1)
     emotion_analysis: EmotionAnalysis = Field(..., description="상세 분석 결과")
 

--- a/app/ai/service.py
+++ b/app/ai/service.py
@@ -3,10 +3,10 @@ import re
 
 import google.generativeai as genai
 
+from app.diary.model import MainEmotionType
 from core.config import AI_SETTINGS
 from core.exceptions import AIServiceError
 
-from ..diary.model import MainEmotion
 from .prompts import SimpleEmotionPrompts
 from .schema import DiaryEmotionRequest, DiaryEmotionResponse, EmotionAnalysis
 
@@ -49,7 +49,7 @@ class DiaryEmotionService:
             )
 
             return DiaryEmotionResponse(
-                main_emotion=MainEmotion(main_emotion),
+                main_emotion=MainEmotionType(main_emotion),
                 emotion_analysis=EmotionAnalysis(**analysis_data),
                 confidence=analysis_data.get("confidence", 0.5),
             )

--- a/app/ai/test_gemini.py
+++ b/app/ai/test_gemini.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 from app.ai.schema import DiaryEmotionRequest, DiaryEmotionResponse, EmotionAnalysis
-from app.diary.model import MainEmotion
+from app.diary.model import MainEmotionType
 
 # 프로젝트 루트 경로 추가
 project_root = Path(__file__).parent.parent.parent
@@ -45,7 +45,7 @@ class MockDiaryEmotionService:
         )
 
         return DiaryEmotionResponse(
-            main_emotion=MainEmotion(emotion),
+            main_emotion=MainEmotionType(emotion),
             emotion_analysis=emotion_analysis,  # 이제 올바른 타입
             confidence=confidence,
         )
@@ -67,7 +67,7 @@ class TestDiaryEmotionService:
 
         result = asyncio.run(mock_service.analyze_diary_emotion(request))
 
-        assert result.main_emotion == MainEmotion.POSITIVE
+        assert result.main_emotion == MainEmotionType.POSITIVE
         assert result.confidence >= 0.7
         assert result.emotion_analysis.reason == "키워드 기반 테스트 분석"
         print("긍정적 감정 분석 테스트 통과")
@@ -82,7 +82,7 @@ class TestDiaryEmotionService:
 
         result = asyncio.run(mock_service.analyze_diary_emotion(request))
 
-        assert result.main_emotion == MainEmotion.NEGATIVE
+        assert result.main_emotion == MainEmotionType.NEGATIVE
         assert result.confidence >= 0.7
         print("부정적 감정 분석 테스트 통과")
 
@@ -95,7 +95,7 @@ class TestDiaryEmotionService:
 
         result = asyncio.run(mock_service.analyze_diary_emotion(request))
 
-        assert result.main_emotion == MainEmotion.NEUTRAL
+        assert result.main_emotion == MainEmotionType.NEUTRAL
         print("중립적 감정 분석 테스트 통과")
 
     def test_service_health_check(self):
@@ -112,12 +112,12 @@ class TestDiaryEmotionService:
         emotion_analysis = EmotionAnalysis(reason="테스트 분석", key_phrases=["테스트"])
 
         response = DiaryEmotionResponse(
-            main_emotion=MainEmotion.POSITIVE,
+            main_emotion=MainEmotionType.POSITIVE,
             emotion_analysis=emotion_analysis,
             confidence=0.9,
         )
 
-        assert response.main_emotion == MainEmotion.POSITIVE
+        assert response.main_emotion == MainEmotionType.POSITIVE
         assert response.confidence == 0.9
         assert isinstance(response.emotion_analysis, EmotionAnalysis)
         assert response.emotion_analysis.reason == "테스트 분석"
@@ -128,7 +128,7 @@ class TestDiaryEmotionService:
         # DB에서 사용하는 값들
         db_emotions = ["긍정", "부정", "중립"]
 
-        for emotion_type in MainEmotion:
+        for emotion_type in MainEmotionType:
             assert emotion_type.value in db_emotions
 
         print("DB 호환성 테스트 통과")
@@ -136,9 +136,9 @@ class TestDiaryEmotionService:
 
 def test_basic_functionality():
     """기본 기능 테스트"""
-    assert MainEmotion.POSITIVE == "긍정"
-    assert MainEmotion.NEGATIVE == "부정"
-    assert MainEmotion.NEUTRAL == "중립"
+    assert MainEmotionType.POSITIVE == "긍정"
+    assert MainEmotionType.NEGATIVE == "부정"
+    assert MainEmotionType.NEUTRAL == "중립"
     print("기본 기능 테스트 통과")
 
 

--- a/app/diary/api.py
+++ b/app/diary/api.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.ai.schema import MainEmotionType
+from app.diary.model import MainEmotionType
 from app.diary.schema import (
     DiaryCreate,
     DiaryListItem,

--- a/app/diary/api.py
+++ b/app/diary/api.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.diary.model import MainEmotion
+from app.ai.schema import MainEmotionType
 from app.diary.schema import (
     DiaryCreate,
     DiaryListItem,
@@ -111,7 +111,7 @@ async def get_diary(diary_id: int):
 async def list_diaries(
     user_id: Optional[int] = Query(None, description="특정 사용자 ID로 필터링"),
     # ✅ Enum으로 검증 ('긍정'/'부정'/'중립' 등) — 미지정 시 None
-    main_emotion: Optional[MainEmotion] = Query(
+    main_emotion: Optional[MainEmotionType] = Query(
         None, description="주요 감정 라벨로 필터링"
     ),
     date_from: Optional[datetime] = Query(None, description="조회 시작일 (YYYY-MM-DD)"),
@@ -129,7 +129,7 @@ async def list_diaries(
         user_id=user_id,
         main_emotion=(
             main_emotion.value
-            if isinstance(main_emotion, MainEmotion)
+            if isinstance(main_emotion, MainEmotionType)
             else main_emotion
         ),
         date_from=date_from,

--- a/app/diary/model.py
+++ b/app/diary/model.py
@@ -1,20 +1,14 @@
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 
 from tortoise import fields
 from tortoise.models import Model
 
+from app.ai.schema import MainEmotionType
 from app.shared.model import TimestampMixin
 
 if TYPE_CHECKING:
     from app.tag.model import Tag
     from app.user.model import User
-
-
-class MainEmotion(StrEnum):
-    POSITIVE = "긍정"
-    NEGATIVE = "부정"
-    NEUTRAL = "중립"
 
 
 class Diary(TimestampMixin, Model):
@@ -28,7 +22,7 @@ class Diary(TimestampMixin, Model):
     # dict 또는 None 저장 가능. 기본값은 None
     emotion_analysis: Optional[dict[str, Any]] = fields.JSONField(null=True)
 
-    main_emotion = fields.CharEnumField(enum_type=MainEmotion, null=True)  # ENUM
+    main_emotion = fields.CharEnumField(enum_type=MainEmotionType, null=True)  # ENUM
 
     user: fields.ForeignKeyRelation["User"] = fields.ForeignKeyField(
         "models.User", related_name="diaries", on_delete=fields.CASCADE

--- a/app/diary/model.py
+++ b/app/diary/model.py
@@ -1,15 +1,21 @@
 import json
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 
 from tortoise import fields
 from tortoise.models import Model
 
-from app.ai.schema import MainEmotionType
 from app.shared.model import TimestampMixin
 
 if TYPE_CHECKING:
     from app.tag.model import Tag  # 실제 Tag 모델이 정의된 경로에 맞춰 수정
     from app.user.model import User  # 실제 User 모델이 정의된 경로에 맞춰 수정
+
+
+class MainEmotionType(StrEnum):
+    POSITIVE = "긍정"
+    NEGATIVE = "부정"
+    NEUTRAL = "중립"
 
 
 class Diary(TimestampMixin, Model):

--- a/app/diary/model.py
+++ b/app/diary/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
@@ -18,54 +20,78 @@ class MainEmotionType(StrEnum):
     NEUTRAL = "중립"
 
 
+# ---------------------------------------------------------------------
+# 다이어리 모델
+# ---------------------------------------------------------------------
+
+
 class Diary(TimestampMixin, Model):
     id = fields.BigIntField(pk=True)
 
     # 자주 조회/정렬될 수 있으니 인덱스 부여
     title = fields.CharField(max_length=50, null=False, index=True)
     content = fields.TextField(null=False)
-
-    # JSON 저장, 기본값은 None
-    emotion_analysis: Optional[dict[str, Any]] = fields.JSONField(null=True)
+    # AI 감정 분석 리포트(JSON) 예시
+    # {
+    #   "main_emotion": "긍정" | "부정" | "중립",   # MainEmotionType (주요 감정)
+    #   "confidence": 0.0 ~ 1.0,                  # 분석 신뢰도(0~1)
+    #   "emotion_analysis_report": {                      # 상세 분석 결과
+    #     "reason": "감정 판단의 근거 텍스트",        # Optional
+    #     "key_phrases": ["핵심", "키워드", "..."]    # 문자열 배열
+    #   }
+    # }
+    emotion_analysis_report: Optional[dict[str, Any]] = fields.JSONField(
+        null=True,
+        description=(
+            "AI 감정 분석 리포트(JSON: main_emotion, confidence, "
+            "emotion_analysis{reason,key_phrases})"
+        ),
+    )
 
     async def save(self, *args, **kwargs):
-        if self.emotion_analysis is not None:
-            if not isinstance(self.emotion_analysis, dict):
-                raise ValueError("emotion_analysis는 dict(JSON object)만 허용합니다.")
-            # 직렬화 가능성 추가 확인(키/값이 직렬화 가능해야 함)
-            json.dumps(self.emotion_analysis, ensure_ascii=False)
+        """
+        JSONField에 'JSON object(dict)'만 저장되도록 가드.
+        (배열/문자열/숫자 등은 허용하지 않음)
+        """
+        v = self.emotion_analysis_report
+        if v is not None:
+            if not isinstance(v, dict):
+                raise ValueError(
+                    "emotion_analysis_report는 dict(JSON object)만 허용합니다."
+                )
+            # 직렬화 가능성 추가 확인(키/값이 JSON 직렬화 가능해야 함)
+            json.dumps(v, ensure_ascii=False)
         return await super().save(*args, **kwargs)
-
-    main_emotion = fields.CharEnumField(enum_type=MainEmotionType, null=True)
 
     user: fields.ForeignKeyRelation["User"] = fields.ForeignKeyField(
         "models.User", related_name="diaries", on_delete=fields.CASCADE
     )
     images: fields.ReverseRelation["Image"]
-    tags: fields.ManyToManyRelation["Tag"] = fields.ManyToManyField(
+    tags: fields.ManyToManyRelation[Tag] = fields.ManyToManyField(
         "models.Tag",
         related_name="diaries",
-        through="models.DiaryTag",  # 아래 명시적 through 모델 사용
-        on_delete=fields.CASCADE,
+        through="diary_tag",  # 아래 DiaryTag 모델의 table 명과 일치해야 함
     )
 
     class Meta:
         table = "diaries"
 
     def __str__(self):
-        return f"Diary(id={self.id}, title={self.title}, emotion={self.main_emotion})"
+        return f"Diary(id={self.id}, title={self.title}, emotion_analysis_report={self.emotion_analysis_report})"
+
+
+# ---------------------------------------------------------------------
+# 이미지 모델
+# ---------------------------------------------------------------------
 
 
 class Image(Model):
-    # Tortoise가 런타임에 만들어주는 FK 컬럼 힌트
-    if TYPE_CHECKING:
-        diary_id: int
 
-    id = fields.BigIntField(pk=True)
+    id = fields.BigIntField(pk=True, generated=True)
 
     # 한 다이어리 내 표시 순서 → 인덱스 부여
     order = fields.IntField(null=False, index=True)
-    image = fields.TextField(null=False)
+    url = fields.TextField(null=False)
 
     diary: fields.ForeignKeyRelation[Diary] = fields.ForeignKeyField(
         "models.Diary", related_name="images", on_delete=fields.CASCADE
@@ -77,7 +103,12 @@ class Image(Model):
         unique_together = (("diary_id", "order"),)
 
     def __str__(self) -> str:
-        return f"Image(id={self.id}, diary_id={self.diary_id}, order={self.order})"
+        return f"Image(id={self.id}, diary_id={self.diary.id}, order={self.order})"
+
+
+# ---------------------------------------------------------------------
+# 다이어리_태그 조인 모델
+# ---------------------------------------------------------------------
 
 
 class DiaryTag(Model):
@@ -87,17 +118,22 @@ class DiaryTag(Model):
     - 조인/필터 성능을 위해 (diary_id, tag_id) 인덱스
     """
 
+    id = fields.IntField(pk=True, generated=True)
     diary: fields.ForeignKeyRelation[Diary] = fields.ForeignKeyField(
-        "models.Diary", on_delete=fields.CASCADE
+        "models.Diary",
+        related_name="diarytag_links",  # 내부 관리용 역참조 이름
+        on_delete=fields.CASCADE,
     )
-    tag: fields.ForeignKeyRelation["Tag"] = fields.ForeignKeyField(
-        "models.Tag", on_delete=fields.CASCADE
+    tag: fields.ForeignKeyRelation[Tag] = fields.ForeignKeyField(
+        "models.Tag",
+        related_name="diarytag_links",  # 내부 관리용 역참조 이름
+        on_delete=fields.CASCADE,
     )
 
     class Meta:
-        table = "diary_tags"
-        unique_together = (("diary_id", "tag_id"),)
-        indexes = (("diary_id", "tag_id"),)
+        table = "diary_tag"
+        unique_together = (("diary", "tag"),)
+        indexes = (("diary", "tag"),)
 
     def __str__(self) -> str:
-        return f"DiaryTag(diary_id={self.diary.id}, tag_id={self.tag.tag_id})"
+        return f"DiaryTag(diary_id={self.diary.id}, tag_id={self.tag.id})"

--- a/app/diary/repository.py
+++ b/app/diary/repository.py
@@ -1,17 +1,18 @@
 import json
-from datetime import datetime
+from datetime import date
 from typing import Any, Iterable, Optional
 
 from tortoise.transactions import in_transaction
 
+from app.ai.schema import DiaryEmotionResponse
 from app.diary.model import Diary, Image
-from app.diary.schema import DiaryCreate, EmotionAnalysis, TagIn
+from app.diary.schema import DiaryCreate, TagIn
 from app.tag.model import Tag
 
 
-def _dumps_ea(ea: Optional[EmotionAnalysis | dict[str, Any]]) -> Optional[str]:
+def _dumps_ea(ea: Optional[DiaryEmotionResponse | dict[str, Any]]) -> Optional[str]:
     """
-    EmotionAnalysis(Pydantic)이나 dict를 DB 저장용 JSON 문자열로 변환
+    DiaryEmotionResponse(Pydantic)이나 dict를 DB 저장용 JSON 문자열로 변환
     """
     if ea is None:
         return None
@@ -78,8 +79,8 @@ async def list_by_filters(
     *,
     user_id: Optional[int] = None,
     main_emotion: Optional[str] = None,
-    date_from: Optional[datetime] = None,
-    date_to: Optional[datetime] = None,
+    date_from: Optional[date] = None,
+    date_to: Optional[date] = None,
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[Diary], int]:

--- a/app/diary/schema.py
+++ b/app/diary/schema.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.diary.model import MainEmotion  # Enum 가정: '긍정'/'부정'/'중립' 등
+from app.ai.schema import MainEmotionType
 
 # ============================================================
 # 1) 공통 유효성 타입(제약 모음)
@@ -29,7 +29,7 @@ class EmotionAnalysis(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    label: Optional[MainEmotion] = Field(
+    label: Optional[MainEmotionType] = Field(
         default=None, description="모델이 예측한 대표 감정 라벨(없으면 null)"
     )
     positive: Optional[float] = Field(None, ge=0.0, le=1.0)
@@ -74,7 +74,7 @@ class DiaryBase(BaseModel):
 
     title: DiaryTitle
     content: DiaryContent
-    main_emotion: Optional[MainEmotion] = Field(
+    main_emotion: Optional[MainEmotionType] = Field(
         default=None, description="주요 감정. 미지정 시 null"
     )
 
@@ -147,7 +147,7 @@ class DiaryUpdate(BaseModel):
 
     title: Optional[DiaryTitle] = None
     content: Optional[DiaryContent] = None
-    main_emotion: Optional[MainEmotion] = None
+    main_emotion: Optional[MainEmotionType] = None
     emotion_analysis: Optional[EmotionAnalysis] = None
     tags: Optional[list[TagIn]] = None
     images: Optional[list[str]] = None
@@ -224,7 +224,7 @@ class DiaryListItem(BaseModel):
     diary_id: int
     user_id: int
     title: str
-    main_emotion: Optional[MainEmotion] = None
+    main_emotion: Optional[MainEmotionType] = None
     created_at: datetime
 
 

--- a/app/diary/schema.py
+++ b/app/diary/schema.py
@@ -6,7 +6,8 @@ from typing import Annotated, Any, Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.ai.schema import DiaryEmotionResponse, MainEmotionType
+from app.ai.schema import DiaryEmotionResponse
+from app.diary.model import MainEmotionType
 
 # ============================================================
 # 1) 공통 유효성 타입(제약 모음)

--- a/app/diary/schema.py
+++ b/app/diary/schema.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Annotated, Any, Optional, Protocol
+from typing import Annotated, Any, List, Optional, Protocol
 
+from fastapi import Form
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.ai.schema import DiaryEmotionResponse
@@ -22,37 +23,13 @@ PageSize = Annotated[int, Field(ge=1, le=100)]
 # ============================================================
 # 2) 공통 서브 모델 (서브 구조, 공용으로 쓰일 수 있는 것들)
 # ============================================================
-# class EmotionAnalysis(BaseModel):
-#     """
-#     감정 분석 결과 구조.
-#     예) {
-#     "main_emotion": "긍정|부정|중립",
-#     "confidence": 0.85,
-#     "reason": "분석 근거를 간단히 설명",
-#     "key_phrases": ["감정을 나타내는 주요 문구들"]
-#     }
-#     """
-
-#     model_config = ConfigDict(from_attributes=True)
-
-#     label: Optional[MainEmotionType] = Field(
-#         default=None, description="모델이 예측한 대표 감정 라벨(없으면 null)"
-#     )
-#     positive: Optional[float] = Field(None, ge=0.0, le=1.0)
-#     negative: Optional[float] = Field(None, ge=0.0, le=1.0)
-#     neutral: Optional[float] = Field(None, ge=0.0, le=1.0)
-
-
 class TagIn(BaseModel):
     """
-    입력용 태그 스키마.
-    - id는 선택(업서트/매핑에 사용 가능)
-    - name은 필수
+    입력용 태그 스키마
+    - name 필수
     """
 
     model_config = ConfigDict(from_attributes=True)
-
-    id: Optional[int] = None
     name: str
 
 
@@ -88,60 +65,47 @@ class DiaryBase(BaseModel):
 class DiaryCreate(DiaryBase):
     """
     다이어리 생성 요청
-    - tags: ["일상","행복"] 또는 [{"name":"일상"},{"id":3,"name":"행복"}] 모두 허용
-    - images: 문자열/리스트 모두 허용, 공백/빈값 제거
     """
 
     model_config = ConfigDict(from_attributes=True)
 
     user_id: int
-    emotion_analysis: Optional[DiaryEmotionResponse] = None
-    tags: list[TagIn] = Field(default_factory=list, description="태그 목록")
-    images: list[str] = Field(default_factory=list, description="이미지 URL 목록")
+    emotion_analysis_report: Optional[DiaryEmotionResponse] = None
+    tags: List[str] = Field(default_factory=list, description="태그 목록")
+    image_urls: List[str] = Field(default_factory=list, description="이미지 URL 목록")
 
-    # ---- 정규화 밸리데이터: tags ----
-    @field_validator("tags", mode="before")
     @classmethod
-    def _coerce_tags(cls, v: Any) -> Any:
-        """
-        허용 인풋:
-          - None                         -> []
-          - "일상"                       -> [{"name":"일상"}]
-          - ["일상","행복"]              -> [{"name":"일상"},{"name":"행복"}]
-          - [{"name":"일상"},{"id":3,"name":"행복"}] -> 그대로
-          - 혼합 리스트도 허용
-        """
-        if v is None:
-            return []
-        if isinstance(v, str):
-            return [{"name": v}]
-        if isinstance(v, list):
-            out: list[dict] = []
-            for item in v:
-                if isinstance(item, str):
-                    out.append({"name": item})
-                elif isinstance(item, dict):
-                    out.append(item)  # name 유효성은 TagIn에서 검증
-                else:
-                    raise TypeError("tags 항목은 문자열 또는 객체여야 합니다.")
-            return out
-        raise TypeError("tags는 리스트 또는 문자열이어야 합니다.")
-
-    # ---- 정규화 밸리데이터: images ----
-    @field_validator("images", mode="before")
-    @classmethod
-    def _coerce_images(cls, v: Any) -> Any:
-        if v is None:
-            return []
-        if isinstance(v, str):
-            v = [v]
-        if not isinstance(v, list):
-            raise TypeError("images는 문자열 리스트여야 합니다.")
-        # 공백/빈값 제거
-        return [s.strip() for s in v if isinstance(s, str) and s.strip()]
+    def as_form(
+        cls,
+        user_id: Annotated[int, Form(...)],
+        title: Annotated[str, Form(...)],
+        content: Annotated[str, Form(...)],
+        tags: Annotated[Optional[List[str]], Form(None)] = None,  # tags=일상&tags=행복
+        image_urls: Annotated[
+            Optional[List[str]], Form(None)
+        ] = None,  # URL로 주는 경우
+        emotion_analysis_report: Annotated[
+            Optional[str], Form(None)
+        ] = None,  # JSON 문자열
+    ) -> "DiaryCreate":
+        return cls.model_validate(
+            {
+                "user_id": user_id,
+                "title": title,
+                "content": content,
+                "tags": tags or [],
+                "image_urls": image_urls or [],
+                "emotion_analysis_report": (
+                    json.loads(emotion_analysis_report)
+                    if isinstance(emotion_analysis_report, str)
+                    and emotion_analysis_report.strip()
+                    else None
+                ),
+            }
+        )
 
 
-class DiaryUpdate(BaseModel):
+class DiaryUpdate(DiaryBase):
     """
     다이어리 부분 수정 요청
     - 모든 필드를 Optional로 선언: 전달된 값만 수정
@@ -151,33 +115,12 @@ class DiaryUpdate(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    title: Optional[DiaryTitle] = None
-    content: Optional[DiaryContent] = None
-    main_emotion: Optional[MainEmotionType] = None
-    emotion_analysis: Optional[DiaryEmotionResponse] = None
-    tags: Optional[list[TagIn]] = None
-    images: Optional[list[str]] = None
+    user_id: int
+    emotion_analysis_report: Optional[DiaryEmotionResponse] = None
+    tags: List[str] = Field(default_factory=list, description="태그 목록")
+    image_urls: List[str] = Field(default_factory=list, description="이미지 URL 목록")
 
-    @field_validator("tags", mode="before")
-    @classmethod
-    def _coerce_tags(cls, v: Any) -> Any:
-        if v is None:
-            return None
-        if isinstance(v, str):
-            return [{"name": v}]
-        if isinstance(v, list):
-            out: list[dict] = []
-            for item in v:
-                if isinstance(item, str):
-                    out.append({"name": item})
-                elif isinstance(item, dict):
-                    out.append(item)
-                else:
-                    raise TypeError("tags 항목은 문자열 또는 객체여야 합니다.")
-            return out
-        raise TypeError("tags는 리스트 또는 문자열이어야 합니다.")
-
-    @field_validator("images", mode="before")
+    @field_validator("image_urls", mode="before")
     @classmethod
     def _coerce_images(cls, v: Any) -> Any:
         if v is None:
@@ -211,11 +154,11 @@ class DiaryResponse(DiaryBase):
 
     model_config = ConfigDict(from_attributes=True)
 
-    diary_id: int
+    id: int
     user_id: int
-    emotion_analysis: Optional[DiaryEmotionResponse] = None
-    tags: list[TagOut] = Field(default_factory=list)
-    images: list[DiaryImageOut] = Field(default_factory=list)
+    emotion_analysis_report: Optional[DiaryEmotionResponse] = None
+    tags: List[TagOut] = Field(default_factory=list)
+    image_urls: List[DiaryImageOut] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -227,7 +170,7 @@ class DiaryListItem(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    diary_id: int
+    id: int
     user_id: int
     title: str
     main_emotion: Optional[MainEmotionType] = None
@@ -277,122 +220,13 @@ class _DiaryLike(Protocol):
     updated_at: Any
 
 
-# ---------- 내부 헬퍼 ----------
-def _safe_ea_to_model(ea: Any) -> Optional[DiaryEmotionResponse]:
-    """
-    emotion_analysis를 DiaryEmotionResponse 모델로 '안전하게' 변환.
-    - None → None
-    - str(JSON) → dict 로드 후 모델 검증
-    - dict → 모델 검증
-    - 이미 모델이면 그대로
-    - 그 외 → None
-    """
-    if ea is None:
-        return None
-
-    if isinstance(ea, DiaryEmotionResponse):
-        return ea
-
-    if isinstance(ea, str):
-        try:
-            loaded = json.loads(ea)
-        except Exception:
-            return None
-        if not isinstance(loaded, dict):
-            return None
-        try:
-            return DiaryEmotionResponse.model_validate(loaded)
-        except Exception:
-            return None
-
-    if isinstance(ea, dict):
-        try:
-            return DiaryEmotionResponse.model_validate(ea)
-        except Exception:
-            return None
-
-    return None
-
-
-def _tag_name(tag: Any) -> str:
-    """
-    Tag 모델 호환:
-    - 우선 .name 사용
-    - 없으면 .tag_name 사용
-    - dict로 들어와도 안전 처리
-    - 둘 다 없으면 빈 문자열
-    """
-    if isinstance(tag, dict):
-        name = tag.get("name") or tag.get("tag_name")
-        return name if isinstance(name, str) else ""
-    name = getattr(tag, "name", None)
-    if isinstance(name, str) and name:
-        return name
-    tag_name = getattr(tag, "tag_name", None)
-    return tag_name if isinstance(tag_name, str) else ""
-
-
-def _image_url(img: Any) -> str:
-    """
-    Image 모델 호환:
-    - 우선 .url 사용
-    - 없으면 .image 사용
-    - dict로 들어와도 안전 처리
-    """
-    if isinstance(img, dict):
-        url = img.get("url") or img.get("image")
-        return url if isinstance(url, str) else ""
-    url = getattr(img, "url", None)
-    if isinstance(url, str) and url:
-        return url
-    image = getattr(img, "image", None)
-    return image if isinstance(image, str) else ""
-
-
-def _image_order(img: Any) -> int:
-    """
-    이미지 정렬 순서 추출 (없으면 1)
-    - dict/객체 모두 호환
-    """
-    if isinstance(img, dict):
-        order = img.get("order", 1)
-        return int(order) if isinstance(order, int) else 1
-    return int(getattr(img, "order", 1))
-
-
 # ---------- 공개 매퍼 ----------
-def to_diary_response_from_model(diary: _DiaryLike) -> DiaryResponse:
-    """
-    Tortoise ORM Diary 객체 → DiaryResponse 스키마 변환
-    (이미 prefetch_related('images','tags','user') 되어 있다고 가정)
-    - N+1 최소화: 서비스/레포 계층에서 prefetch 권장
-    """
-    _tags = getattr(diary, "tags", []) or []
-    _images = getattr(diary, "images", []) or []
-
-    return DiaryResponse(
-        diary_id=diary.id,
-        user_id=diary.user_id,
-        title=diary.title,
-        content=diary.content,
-        main_emotion=getattr(diary, "main_emotion", None),
-        emotion_analysis=_safe_ea_to_model(getattr(diary, "emotion_analysis", None)),
-        tags=[TagOut(name=_tag_name(t)) for t in _tags],
-        images=[
-            DiaryImageOut(url=_image_url(img), order=_image_order(img))
-            for img in _images
-        ],
-        created_at=diary.created_at,
-        updated_at=diary.updated_at,
-    )
-
-
 def to_diary_list_item_from_model(diary: _DiaryLike) -> DiaryListItem:
     """
     Tortoise ORM Diary 객체 → 목록 요약 스키마(DiaryListItem) 변환
     """
     return DiaryListItem(
-        diary_id=diary.id,
+        id=diary.id,
         user_id=diary.user_id,
         title=diary.title,
         main_emotion=getattr(diary, "main_emotion", None),

--- a/app/diary/service.py
+++ b/app/diary/service.py
@@ -4,8 +4,9 @@ from collections import Counter
 from datetime import date, datetime
 from typing import Any, Dict, Mapping, Optional, Union
 
-from app.ai.schema import DiaryEmotionResponse, MainEmotionType
+from app.ai.schema import DiaryEmotionResponse
 from app.diary import repository
+from app.diary.model import MainEmotionType
 from app.diary.schema import (
     DiaryCreate,
     DiaryImageOut,

--- a/app/diary/service.py
+++ b/app/diary/service.py
@@ -5,8 +5,8 @@ from collections import Counter
 from datetime import datetime
 from typing import Any, Dict, Mapping, Optional
 
+from app.ai.schema import MainEmotionType
 from app.diary import repository
-from app.diary.model import MainEmotion
 from app.diary.schema import (
     DiaryCreate,
     DiaryImageOut,
@@ -30,7 +30,7 @@ def _ea_to_dict(ea: Optional[EmotionAnalysis]) -> Optional[dict]:
 
 # main_emotion이 없을 때, emotion_analysis 기반으로 최종 감정을 추론하는 함수
 def _infer_final_emotion(
-    main_emotion: Optional[str | MainEmotion],
+    main_emotion: Optional[str | MainEmotionType],
     ea: Optional[Mapping[str, Any]],
 ) -> str:
     """
@@ -44,7 +44,7 @@ def _infer_final_emotion(
     if main_emotion:
         return (
             main_emotion.value
-            if isinstance(main_emotion, MainEmotion)
+            if isinstance(main_emotion, MainEmotionType)
             else str(main_emotion)
         )
 
@@ -186,7 +186,7 @@ class DiaryService:
         if payload.main_emotion is not None:
             patch["main_emotion"] = (
                 payload.main_emotion.value
-                if isinstance(payload.main_emotion, MainEmotion)
+                if isinstance(payload.main_emotion, MainEmotionType)
                 else payload.main_emotion
             )
         if payload.emotion_analysis is not None:
@@ -255,10 +255,10 @@ class DiaryService:
             return None
 
         # 3) main_emotion을 문자열로 통일하는 헬퍼 (Enum/str 혼용 대비)
-        def _norm_emotion(e: Optional[str | MainEmotion]) -> Optional[str]:
+        def _norm_emotion(e: Optional[str | MainEmotionType]) -> Optional[str]:
             if e is None:
                 return None
-            return e.value if isinstance(e, MainEmotion) else str(e)
+            return e.value if isinstance(e, MainEmotionType) else str(e)
 
         # 4) 카운터로 감정별 집계
         counter: Counter[str] = Counter()

--- a/app/diary/service.py
+++ b/app/diary/service.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import json
 from collections import Counter
 from datetime import date, datetime
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, Mapping, Optional, Union, cast
 
-from app.ai.schema import DiaryEmotionResponse
+import anyio
+from fastapi import logger
+from pydantic import BaseModel
+from tortoise.transactions import in_transaction
+
+from app.ai.schema import DiaryEmotionRequest
+from app.ai.service import DiaryEmotionService
 from app.diary import repository
-from app.diary.model import MainEmotionType
+from app.diary.model import Diary, MainEmotionType
 from app.diary.schema import (
     DiaryCreate,
     DiaryImageOut,
@@ -14,62 +21,31 @@ from app.diary.schema import (
     DiaryUpdate,
     TagOut,
 )
+from core.config import AI_ENABLED
 
-# ---------------------------------------------------------------------
-# 내부 유틸 함수 (emotion_analysis 처리용)
-# ---------------------------------------------------------------------
+# ------------------------------------------------------------
+# 공용 유틸
+# ------------------------------------------------------------
 
 
-# DiaryEmotionResponse → dict 변환 (DB 저장 시 JSON으로 직렬화하기 위함)
-def _ea_to_dict(ea: Optional[DiaryEmotionResponse]) -> Optional[dict]:
-    if ea is None:
+def to_dict(
+    obj: Optional[Union[BaseModel, Mapping[str, Any]]],
+    *,
+    exclude_none: bool = True,
+) -> Optional[dict[str, Any]]:
+    """
+    Pydantic / Mapping → dict 변환
+    - BaseModel → model_dump(mode='json')
+    - Mapping   → dict(...) (exclude_none=True면 None 제거)
+    - None      → None
+    """
+    if obj is None:
         return None
-    return ea.model_dump()  # pydantic v1 기준
-
-
-# main_emotion이 없을 때, emotion_analysis 기반으로 최종 감정을 추론하는 함수
-def _infer_final_emotion(
-    main_emotion: Optional[str | MainEmotionType],
-    ea: Optional[Mapping[str, Any]],
-) -> str:
-    """
-    main_emotion이 있는 diary 대상으로
-    - main_emotion 우선
-    - 없으면 ea["label"]
-    - 그래도 없으면 positive/negative/neutral 점수 중 가장 높은 값
-    - 아무 정보가 없으면 "UNSPECIFIED"
-    """
-    # 1) main_emotion 지정돼 있으면 그대로 반환
-    if main_emotion:
-        return (
-            main_emotion.value
-            if isinstance(main_emotion, MainEmotionType)
-            else str(main_emotion)
-        )
-
-    # 2) ea가 없으면 추론 불가
-    if ea is None:
-        return "UNSPECIFIED"
-
-    # 3) label 직접 지정돼 있으면 그대로 반환
-    label = ea.get("label")
-    if isinstance(label, str) and label:
-        return label
-
-    # 4) 점수 기반 추론
-    scores: Dict[str, float] = {}
-    for key in ("positive", "negative", "neutral"):
-        v = ea.get(key)
-        if isinstance(v, (int, float)):
-            scores[key] = float(v)
-
-    if not scores:
-        return "UNSPECIFIED"
-
-    best_key, _ = max(scores.items(), key=lambda kv: kv[1])
-    return {"positive": "긍정", "negative": "부정", "neutral": "중립"}.get(
-        best_key, "UNSPECIFIED"
-    )
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json", exclude_none=exclude_none)
+    if isinstance(obj, Mapping):
+        return {k: v for k, v in obj.items() if (v is not None or not exclude_none)}
+    raise TypeError(f"to_dict 변환 불가: {type(obj)!r}")
 
 
 # Diary ORM 객체 → DiaryResponse(Pydantic) 변환
@@ -80,20 +56,16 @@ def to_diary_response(diary) -> DiaryResponse:
     (이미 prefetch_related('images','tags','user')가 되어 있다고 가정)
     """
     return DiaryResponse(
-        diary_id=diary.id,
+        id=diary.id,
         user_id=diary.user_id,
         title=diary.title,
         content=diary.content,
-        main_emotion=diary.main_emotion,
-        emotion_analysis=diary.emotion_analysis,
-        # tags=[TagOut(name=t.name) for t in getattr(diary, "tags", [])],
-        tags=[
-            TagOut(name=getattr(t, "tag_name", "")) for t in getattr(diary, "tags", [])
-        ],
-        images=[
+        emotion_analysis_report=diary.emotion_analysis_report,
+        tags=[TagOut(name=getattr(t, "name", "")) for t in getattr(diary, "tags", [])],
+        image_urls=[
             DiaryImageOut(
                 url=getattr(
-                    img, "url", getattr(img, "image", "")
+                    img, "url", getattr(img, "image_urls", "")
                 ),  # url or image 필드 호환
                 order=img.order,
             )
@@ -108,38 +80,133 @@ def to_diary_response(diary) -> DiaryResponse:
 def _norm_emotion(e: Optional[Union[str, MainEmotionType]]) -> Optional[str]:
     if e is None:
         return None
-
     if isinstance(e, MainEmotionType):
         return e.value
-
     s = str(e).strip()
     if not s:
         raise ValueError("main_emotion은 비어 있을 수 없습니다.")
-
     try:
         return MainEmotionType(s).value
     except ValueError:
         allowed = ", ".join(m.value for m in MainEmotionType)
-        raise ValueError(f"Invalid main_emotion: {s!r}. 허용값: [{allowed}]")
+        raise ValueError(f"허용하지 않는 emotion 값입니다: {s!r}. 허용값: [{allowed}]")
+
+
+def _resolve_ai() -> Optional[DiaryEmotionService]:
+    """
+    AI 사용 가능 여부 확인 후 인스턴스 생성
+    - 키 미설정/초기화 실패 시 None 반환 → 서비스에서 자동 스킵
+    """
+    if not AI_ENABLED:
+        return None
+    try:
+        return DiaryEmotionService()
+    except Exception:
+        return None
+
+
+def _extract_main_emotion_from_report(rep_obj: Any) -> Optional[str]:
+    """
+    다양한 형태의 emotion_analysis_report에서 main_emotion만 안전하게 추출
+    - str(JSON), dict, BaseModel, None 모두 처리
+    """
+    if rep_obj is None:
+        rep_dict: Dict[str, Any] = {}
+    elif isinstance(rep_obj, str):
+        try:
+            parsed = json.loads(rep_obj)
+            rep_dict = parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            rep_dict = {}
+    elif hasattr(rep_obj, "model_dump"):
+        rep_dict = cast(Dict[str, Any], rep_obj.model_dump())
+    elif isinstance(rep_obj, dict):
+        rep_dict = cast(Dict[str, Any], rep_obj)
+    else:
+        rep_dict = {}
+
+    ea: Any = rep_dict.get("emotion_analysis")
+    if isinstance(ea, dict):
+        me = ea.get("main_emotion")
+    return _norm_emotion(me)
 
 
 # ---------------------------------------------------------------------
 # 서비스 계층 (비즈니스 로직 담당)
 # 컨트롤러(api.py)와 DB(repository.py) 사이에서 중간 역할
 # ---------------------------------------------------------------------
-
-
 class DiaryService:
     @staticmethod
-    async def create(payload: DiaryCreate) -> DiaryResponse:
+    async def create(
+        payload: DiaryCreate,
+    ) -> DiaryResponse:
         """
-        다이어리 생성 서비스
-        - repository.create 호출해서 DB 저장
-        - DiaryEmotionResponse JSON 직렬화해서 DB 저장
-        - 결과를 DiaryResponse 형태로 변환 후 반환
+        1) 다이어리 생성(트랜잭션)
+        2) 태그/이미지 전체 교체 저장
+        3) 커밋 이후 AI 분석(가능하면) → main_emotion / emotion_analysis_report DB 반영
+        4) 최종 DiaryResponse 반환(태그/이미지/감정 포함)
         """
-        created = await repository.create(payload)
-        return to_diary_response(created)
+        ai = _resolve_ai()
+
+        # 1) 생성 + 관계 저장
+        async with in_transaction() as conn:
+            diary: Diary = await repository.create(payload, using_db=conn)
+
+            if payload.tags:
+                # 레포지토리 시그니처에 맞춰 전달 (TagIn 리스트 or 이름 리스트)
+                await repository.replace_tags(diary, payload.tags, using_db=conn)
+
+            if payload.image_urls:
+                await repository.replace_images(
+                    diary, payload.image_urls, using_db=conn
+                )
+
+        # 3) 커밋 이후 AI 분석
+        ai_result = None
+        # 2) 커밋 이후 AI 분석(선택)
+        if ai and not payload.emotion_analysis_report:
+            try:
+                # 타임아웃: 지연되면 감정분석만 생략하고 생성은 유지
+                with anyio.move_on_after(6) as scope:
+                    req = DiaryEmotionRequest(
+                        diary_content=payload.content,
+                        user_id=payload.user_id,
+                    )
+                    ai_result = await ai.analyze_diary_emotion(req)
+
+                    # DB 반영: main_emotion + emotion_analysis_report
+                    await repository.update_partially(
+                        diary,
+                        {
+                            "main_emotion": _norm_emotion(
+                                getattr(ai_result, "main_emotion", None)
+                            ),
+                            "emotion_analysis_report": to_dict(ai_result),
+                        },
+                    )
+
+                if scope.cancelled_caught:
+                    logger.logger.warning(
+                        "AI 분석 타임아웃: 감정분석 생략(생성은 유지)"
+                    )
+            except Exception as e:
+                logger.logger.warning("AI 분석 실패(생성은 유지): %s", e)
+
+        resp = await repository.get_by_id(diary.id)
+        trans_resp = to_diary_response(resp)
+        trans_resp.tags = [
+            TagOut(name=(t.name if hasattr(t, "name") else str(t)).strip())
+            for t in (payload.tags or [])
+            if isinstance(getattr(t, "name", t), str)
+            and str(getattr(t, "name", t)).strip()
+        ]
+        trans_resp.image_urls = [
+            DiaryImageOut(url=u, order=i + 1) for i, u in enumerate(payload.image_urls)
+        ]
+        if ai_result is not None:
+            trans_resp.emotion_analysis_report = ai_result
+
+        return trans_resp
 
     @staticmethod
     async def get(diary_id: int) -> Optional[DiaryResponse]:
@@ -180,38 +247,54 @@ class DiaryService:
     async def update(diary_id: int, payload: DiaryUpdate) -> Optional[DiaryResponse]:
         """
         다이어리 수정 서비스
-        - 필요한 값만 patch dict에 담아 repository.update_partially 호출
-        - tags/images는 전체 교체 정책
+        - 스칼라 필드만 부분 업데이트
+        - tags / image_urls 는 '전체 교체' 정책
+        - 최종 응답은 repository.to_response 로 일관 반환
         """
         d = await repository.get_by_id(diary_id)
         if not d:
             return None
 
-        patch: dict = {}
+        # 1) 스칼라 부분 업데이트 패치 구성
+        patch: Dict[str, Any] = {}
         if payload.title is not None:
             patch["title"] = payload.title
         if payload.content is not None:
             patch["content"] = payload.content
-        if payload.main_emotion is not None:
-            patch["main_emotion"] = (
-                payload.main_emotion.value
-                if isinstance(payload.main_emotion, MainEmotionType)
-                else payload.main_emotion
-            )
-        if payload.emotion_analysis is not None:
-            patch["emotion_analysis"] = _ea_to_dict(payload.emotion_analysis)
 
-        # DB 반영
-        d = await repository.update_partially(d, patch)
+        if payload.emotion_analysis_report is not None:
+            ea = payload.emotion_analysis_report
+            if hasattr(ea, "model_dump"):
+                patch["emotion_analysis_report"] = ea.model_dump()
+            elif isinstance(ea, dict):
+                patch["emotion_analysis_report"] = ea
+            else:
+                patch["emotion_analysis_report"] = (
+                    ea  # str/기타도 JSONField가 수용하면 그대로
+                )
 
-        # 태그/이미지 교체
+        if patch:
+            d = await repository.update_partially(d, patch)
+        # 2) 관계 전체 교체
         if payload.tags is not None:
             await repository.replace_tags(d, payload.tags)
-        if payload.images is not None:
-            await repository.replace_images(d, payload.images)
 
-        d = await repository.get_by_id(diary_id)
-        return to_diary_response(d) if d else None
+        if payload.image_urls is not None:
+            await repository.replace_images(d, payload.image_urls)
+        trans_resp = to_diary_response(d)
+        trans_resp.tags = [
+            TagOut(name=(t.name if hasattr(t, "name") else str(t)).strip())
+            for t in (payload.tags or [])
+            if isinstance(getattr(t, "name", t), str)
+            and str(getattr(t, "name", t)).strip()
+        ]
+        trans_resp.image_urls = [
+            DiaryImageOut(url=u, order=i + 1) for i, u in enumerate(payload.image_urls)
+        ]
+        print("service.payload", payload)
+        print("service.d", trans_resp)
+        # 3) 최종 응답(태그/이미지/감정 포함)
+        return trans_resp
 
     @staticmethod
     async def delete(diary_id: int) -> bool:
@@ -251,9 +334,31 @@ class DiaryService:
         counter: Counter[str] = Counter()
 
         for r in rows:
-            # main_emotion만 사용 (없으면 카운트 생략)
-            label = _norm_emotion(r.main_emotion)
-            if label is not None:
+            rep_obj: Any = getattr(r, "emotion_analysis_report", None)
+
+            if rep_obj is None:
+                rep_dict: Dict[str, Any] = {}
+            elif isinstance(rep_obj, str):
+                try:
+                    parsed = json.loads(rep_obj)
+                    rep_dict = parsed if isinstance(parsed, dict) else {}
+                except Exception:
+                    rep_dict = {}
+            elif hasattr(rep_obj, "model_dump"):
+                rep_dict = cast(Dict[str, Any], rep_obj.model_dump())
+            elif isinstance(rep_obj, dict):
+                rep_dict = rep_obj
+            else:
+                rep_dict = {}
+
+            me: Any = rep_dict.get("main_emotion")
+            if me is None:
+                ea = rep_dict.get("emotion_analysis")
+                if isinstance(ea, dict):
+                    me = ea.get("main_emotion")
+
+            label = _norm_emotion(me)
+            if label:
                 counter[label] += 1
 
         # 5) {"긍정": 3, "부정": 1, "중립": 2, "UNSPECIFIED": 0, ...} 형태로 반환

--- a/app/diary/test_diary.py
+++ b/app/diary/test_diary.py
@@ -1,5 +1,13 @@
+# =============================================================================
+# 다이어리 API 통합 테스트 (멀티파트 업로드 + 태그/이미지 저장 + AI 스텁)
+# - httpx AsyncClient 로 FastAPI 라우터 호출
+# - Tortoise ORM: in-memory SQLite 사용 (매 테스트 케이스마다 초기화)
+# =============================================================================
+
+import base64
+import json
 import uuid
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List, Optional
 
 import pytest
 import pytest_asyncio
@@ -7,42 +15,82 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from tortoise import Tortoise
 
+from app.ai.schema import DiaryEmotionResponse, EmotionAnalysis
 from app.diary.api import router as diary_router
+from app.diary.service import _resolve_ai
 from app.user.model import User
 
-# ------------------------------
-# 테스트용 간단 User/Tag 모델 (실제 앱 모델로 대체 가능)
-# ------------------------------
-# class User(Model):
-#     id = fields.IntField(pk=True)
-#     email = fields.CharField(max_length=255, unique=True, null=False)
-
-#     class Meta:
-#         table = "users"
-
-
-# class Tag(Model):
-#     id = fields.IntField(pk=True)
-#     name = fields.CharField(max_length=50, unique=True, null=False)
-
-#     class Meta:
-#         table = "tags"
-
-
-# ------------------------------
-# Pytest 설정
-# ------------------------------
+# pytest-asyncio 만 사용
 pytestmark = pytest.mark.asyncio
 
 
+# =============================================================================
+# 상수/테스트용 바이너리
+# =============================================================================
+
+# 1x1 투명 PNG (유효한 이미지 바이트)
+_PNG_1x1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6p2tQAAAAASUVORK5CYII="
+)
+
+
+# =============================================================================
+# 공용 헬퍼
+# =============================================================================
+def _mp_file(field: str, name: str, content: bytes, content_type: str):
+    """httpx files 인자 편의 함수: (필드명, (파일명, 바이트, MIME))"""
+    return (field, (name, content, content_type))
+
+
+async def _post_diary_multipart(
+    client: AsyncClient, payload: dict, image_files: Optional[List[tuple]] = None
+):
+    """
+    멀티파트 요청 전송:
+    - 본문 JSON은 'payload_json' 필드에 문자열로
+    - 파일은 'image_files' 필드에 다중 첨부
+    """
+    data = {"payload_json": json.dumps(payload, ensure_ascii=False)}
+    files = []
+    if image_files:
+        for fname, bts, ctype in image_files:
+            files.append(_mp_file("image_files", fname, bts, ctype))
+    return await client.post("/diaries", data=data, files=files or None)
+
+
+async def _patch_diary_multipart(
+    client: AsyncClient, diary_id: int, patch: dict, image_files=None
+):
+    data = {"payload_json": json.dumps(patch, ensure_ascii=False)}
+    files = []
+    if image_files:
+        for fname, bts, ctype in image_files:
+            files.append(("image_files", (fname, bts, ctype)))
+    return await client.patch(f"/diaries/{diary_id}", data=data, files=files or None)
+
+
+# =============================================================================
+# AI 스텁 (의존성 오버라이드로 주입)
+# =============================================================================
+class _StubAI:
+    async def analyze_diary_emotion(self, req):
+        # 서비스/레포지토리가 그대로 소화할 수 있는 Pydantic 모델 반환
+        return DiaryEmotionResponse(
+            main_emotion="긍정",
+            confidence=1.0,
+            emotion_analysis=EmotionAnalysis(
+                reason="stub",
+                key_phrases=["테스트", "스텁"],
+            ),
+        )
+
+
+# =============================================================================
+# 앱/클라이언트 픽스처
+# =============================================================================
 @pytest_asyncio.fixture(scope="session")
 async def app() -> AsyncGenerator[FastAPI, None]:
-    """
-    테스트용 FastAPI 앱 구성 (운영 코드와 분리)
-    - in-memory sqlite 사용
-    - 실제 다이어리 라우터 mount
-    - Tortoise는 테스트에서 직접 init
-    """
+    """테스트용 FastAPI 앱에 실제 다이어리 라우터 장착"""
     app = FastAPI(title="Test Diary API")
     app.include_router(diary_router)
     yield app
@@ -51,20 +99,26 @@ async def app() -> AsyncGenerator[FastAPI, None]:
 @pytest_asyncio.fixture
 async def client(app: FastAPI):
     """
-    테스트 클라이언트
-    - Tortoise ORM 직접 초기화 (register_tortoise 사용 안 함)
+    - FastAPI 의존성 오버라이드로 AI 스텁 주입
+    - Tortoise ORM in-memory SQLite 초기화
+    - httpx AsyncClient 구성
     """
+    # 테스트에서만 AI 의존성 오버라이드
+    app.dependency_overrides[_resolve_ai] = lambda: _StubAI()
+
+    # ORM 초기화(테스트 모델 등록)
+    #   - Tag 모델이 app.diary.model 안으로 통합됐다면 "app.tag.model" 항목을 제거하세요.
     await Tortoise.init(
         config={
             "connections": {"default": "sqlite://:memory:"},
             "apps": {
                 "models": {
                     "models": [
-                        "app.user.model",  # User
-                        "app.tag.model",  # Tag
-                        "app.diary.model",  # Diary, Image, DiaryTag
-                        "app.notification.model",  # Notification
-                        "aerich.models",  # 마이그레이션용
+                        "app.user.model",
+                        "app.diary.model",
+                        "app.tag.model",
+                        "app.notification.model",
+                        "aerich.models",
                     ],
                     "default_connection": "default",
                 }
@@ -75,7 +129,7 @@ async def client(app: FastAPI):
     )
     await Tortoise.generate_schemas()
 
-    # httpx AsyncClient 준비
+    # HTTP 클라이언트
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
@@ -83,156 +137,206 @@ async def client(app: FastAPI):
     await Tortoise.close_connections()  # type: ignore[attr-defined]
 
 
-# ------------------------------
-# 헬퍼: 유저 생성
-# ------------------------------
+# =============================================================================
+# 데이터 준비 헬퍼
+# =============================================================================
 async def _ensure_user(email: str = "") -> int:
+    """테스트용 사용자 1명 생성 후 id 반환"""
+    suffix = uuid.uuid4().hex[:8]
     if not email:
-        email = f"u_{uuid.uuid4().hex[:8]}@test.com"
+        email = f"u_{suffix}@test.com"
     u = await User.create(
         email=email,
         password="test1234",
-        nickname="tester",
+        nickname=f"tester_{suffix}",
         username="테스터",
         phonenumber="010-0000-0000",
     )
     return u.id
 
 
-# ------------------------------
-# 테스트: 다이어리 생성
-# ------------------------------
-async def test_create_diary(client: AsyncClient):
-    user_id = await _ensure_user()
+# =============================================================================
+# 테스트 케이스
+# =============================================================================
 
+
+async def test_create_diary(client: AsyncClient, monkeypatch):
+    """
+    다이어리 생성 (멀티파트 + 파일 업로드 스텁 + AI 스텁 동작)
+    - Cloudinary 업로드는 라우터 네임스페이스에서 스텁으로 대체
+    - 응답의 image_urls에 업로드된 URL이 포함되는지 검증
+    """
+
+    # Cloudinary 업로드 스텁: 업로드된 파일 "이름"으로 URL 생성
+    async def _stub_upload_images_to_urls(files, opts=None):
+        return [
+            f"https://cdn.example/{getattr(f, 'filename', 'unnamed')}"
+            for f in (files or [])
+        ]
+
+    # ✅ 반드시 라우터 네임스페이스 기준으로 패치
+    monkeypatch.setattr(
+        "app.diary.api.CloudinaryService.upload_images_to_urls",
+        _stub_upload_images_to_urls,
+    )
+
+    user_id = await _ensure_user()
+    payload_json = {
+        "user_id": user_id,
+        "title": "오늘의 일기",
+        "content": "날씨가 좋았다. 그래서 신나게 산책을 나갔다",
+        "phonenumber": "010-1234-5678",
+        "emotion_analysis_report": None,
+        "tags": ["일상", "행복"],
+    }
+
+    # (필드명, 파일명, 바이트, MIME)
+    image_files = [
+        ("a.png", _PNG_1x1, "image/png"),
+        ("b.png", _PNG_1x1, "image/png"),
+    ]
+
+    res = await _post_diary_multipart(client, payload_json, image_files=image_files)
+    assert res.status_code == 201, res.text
+    data = res.json()
+
+    # 기본 필드 검증
+    assert data["id"] > 0
+    assert data["user_id"] == user_id
+    assert data["title"] == payload_json["title"]
+    assert data["content"] == payload_json["content"]
+
+    # 이미지 URL 추출 유틸 (list[str] 또는 list[{url:...}] 모두 대응)
+    def _extract_urls(imgs):
+        if not imgs:
+            return []
+        if isinstance(imgs[0], str):
+            return imgs
+        if isinstance(imgs[0], dict):
+            return [i.get("url") for i in imgs]
+        return imgs
+
+    urls = _extract_urls(data.get("image_urls") or [])
+    assert urls == ["https://cdn.example/a.png", "https://cdn.example/b.png"]
+
+
+async def test_get_diary(client: AsyncClient):
+    """
+    다이어리 단건 조회
+    - 먼저 멀티파트로 생성 후 /diaries/{id} 조회
+    """
+    user_id = await _ensure_user()
     payload = {
         "user_id": user_id,
         "title": "오늘의 일기",
         "content": "날씨가 좋았다.",
-        "phonenumber": "010-1234-5678",
-        "main_emotion": None,  # 미지정 → null
-        "emotion_analysis": {
-            "label": None,
-            "positive": 0.7,
-            "negative": 0.1,
-            "neutral": 0.2,
-        },
+        "main_emotion": None,
+        "emotion_analysis_report": None,
         "tags": ["일상", "행복"],
-        "images": ["http://img/1.png", "http://img/2.png"],
+        "image_urls": ["http://img/1.png", "http://img/2.png"],
     }
 
-    res = await client.post("/diaries", json=payload)
+    res = await _post_diary_multipart(client, payload, image_files=None)
     assert res.status_code == 201, res.text
-    data = res.json()
-
-    # 필수 필드 검증
-    assert data["diary_id"] > 0
-    assert data["user_id"] == user_id
-    assert data["title"] == payload["title"]
-    assert data["content"] == payload["content"]
-    assert data["main_emotion"] is None  # 미지정이면 null
-    assert data["emotion_analysis"]["positive"] == 0.7
-
-    # 관계 필드 검증
-    assert [t["name"] for t in data["tags"]] == ["일상", "행복"]
-    assert [i["url"] for i in data["images"]] == [
-        "http://img/1.png",
-        "http://img/2.png",
-    ]
-
-
-async def test_get_diary(client: AsyncClient):
-    user_id = await _ensure_user()
-
-    # 먼저 생성
-    res = await client.post(
-        "/diaries",
-        json={
-            "user_id": user_id,
-            "title": "조회 테스트",
-            "content": "내용",
-            "tags": ["A"],
-            "images": ["http://img/a.png"],
-        },
-    )
     d = res.json()
-    diary_id = d["diary_id"]
+    diary_id = d["id"]
 
     # 조회
     res2 = await client.get(f"/diaries/{diary_id}")
     assert res2.status_code == 200, res2.text
     got = res2.json()
 
-    assert got["diary_id"] == diary_id
-    assert got["title"] == "조회 테스트"
-    assert got["tags"][0]["name"] == "A"
-    assert got["images"][0]["url"] == "http://img/a.png"
+    assert got["id"] == diary_id
+    assert got["title"] == payload["title"]
+    assert got.get("tags") is not None
+    assert got.get("image_urls") is not None
 
 
-# ------------------------------
-# 테스트: 다이어리 수정 (부분 수정 + 태그/이미지 교체)
-# ------------------------------
 async def test_update_diary(client: AsyncClient):
+    """
+    ✅ 다이어리 부분 수정(PATCH)
+    - 제목/내용 교체 + 태그/이미지 전체 교체
+    """
     user_id = await _ensure_user()
 
-    # 생성
-    res = await client.post(
-        "/diaries",
-        json={
-            "user_id": user_id,
-            "title": "수정 전 제목",
-            "content": "수정 전 내용",
-            "tags": ["초기"],
-            "images": ["http://img/before.png"],
-        },
-    )
+    # 먼저 생성
+    user_id = await _ensure_user()
+    payload_json = {
+        "user_id": user_id,
+        "title": "오늘의 일기",
+        "content": "날씨가 좋았다.",
+        "main_emotion": None,
+        "emotion_analysis_report": None,
+        "tags": ["일상", "행복"],
+        "image_urls": ["http://img/1.png", "http://img/2.png"],
+    }
+    res = await _post_diary_multipart(client, payload_json, image_files=None)
+    assert res.status_code == 201, res.text
     d = res.json()
-    diary_id = d["diary_id"]
+    diary_id = d["id"]
 
-    # PATCH: 제목/내용 변경 + 태그/이미지 전체 교체
+    # PATCH (서버 구현에 따라 JSON 또는 multipart 가능)
     patch = {
+        "user_id": user_id,
         "title": "수정 후 제목",
         "content": "수정 후 내용",
         "tags": ["교체1", "교체2"],
-        "images": ["http://img/after1.png", "http://img/after2.png"],
-        # main_emotion/emotion_analysis는 생략 (부분 수정 가능)
+        "image_urls": ["http://img/after1.png", "http://img/after2.png"],
     }
-    res2 = await client.patch(f"/diaries/{diary_id}", json=patch)
+    res2 = await _patch_diary_multipart(client, diary_id, patch, image_files=None)
     assert res2.status_code == 200, res2.text
     upd = res2.json()
 
+    def _names(tags):
+        if not tags:
+            return []
+        if isinstance(tags[0], str):
+            return tags
+        if isinstance(tags[0], dict):
+            return [t.get("name") for t in tags]
+        return tags
+
+    def _urls(imgs):
+        if not imgs:
+            return []
+        if isinstance(imgs[0], str):
+            return imgs
+        if isinstance(imgs[0], dict):
+            return [i.get("url") for i in imgs]
+        return imgs
+
     assert upd["title"] == "수정 후 제목"
     assert upd["content"] == "수정 후 내용"
-    assert [t["name"] for t in upd["tags"]] == ["교체1", "교체2"]
-    assert [i["url"] for i in upd["images"]] == [
+    assert _names(upd.get("tags")) == ["교체1", "교체2"]
+    assert _urls(upd.get("images") or upd.get("image_urls")) == [
         "http://img/after1.png",
         "http://img/after2.png",
     ]
 
 
-# ------------------------------
-# 테스트: 목록 조회 + 페이징/필터
-# ------------------------------
 async def test_list_diaries_with_filters(client: AsyncClient):
+    """
+    ✅ 목록 조회 + 페이징/필터
+    - 동일 유저로 3건 생성 후 page=1, page_size=2 조회
+    """
     user_id = await _ensure_user()
 
-    # 3건 생성
     for i in range(3):
-        await client.post(
-            "/diaries",
-            json={
+        await _post_diary_multipart(
+            client,
+            {
                 "user_id": user_id,
                 "title": f"목록 {i}",
                 "content": "내용",
                 "tags": ["m"],
             },
+            image_files=None,
         )
 
-    # 페이지 1 / 페이지당 2
     res = await client.get(
         "/diaries", params={"user_id": user_id, "page": 1, "page_size": 2}
     )
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     body = res.json()
     assert body["meta"]["page"] == 1
     assert body["meta"]["page_size"] == 2
@@ -240,50 +344,72 @@ async def test_list_diaries_with_filters(client: AsyncClient):
     assert len(body["items"]) == 2
 
 
-# ------------------------------
-# 테스트: 감정 통계 (main_emotion 미지정 시 분석 추론)
-# ------------------------------
 async def test_emotion_stats_inferred(client: AsyncClient):
+    """
+    ✅ 감정 통계
+    - emotion_analysis_report.main_emotion 을 기준으로 집계되는지 검증
+    - 긍정/부정/중립 각각 최소 1개 이상 생성
+    """
     user_id = await _ensure_user()
 
-    # 긍정 추론 케이스
-    await client.post(
-        "/diaries",
-        json={
+    # 긍정
+    await _post_diary_multipart(
+        client,
+        {
             "user_id": user_id,
             "title": "emo1",
             "content": "c1",
-            "emotion_analysis": {"positive": 0.9, "negative": 0.05, "neutral": 0.05},
+            "emotion_analysis_report": {
+                "main_emotion": "긍정",
+                "confidence": 1.0,
+                "emotion_analysis": {
+                    "reason": "감정 판단의 근거 텍스트",
+                    "key_phrases": ["핵심", "키워드", "..."],
+                },
+            },
         },
+        image_files=None,
     )
-    # 부정 추론 케이스
-    await client.post(
-        "/diaries",
-        json={
+    # 부정
+    await _post_diary_multipart(
+        client,
+        {
             "user_id": user_id,
             "title": "emo2",
             "content": "c2",
-            "emotion_analysis": {"positive": 0.1, "negative": 0.8, "neutral": 0.1},
+            "emotion_analysis_report": {
+                "main_emotion": "부정",
+                "confidence": 1.0,
+                "emotion_analysis": {
+                    "reason": "감정 판단의 근거 텍스트",
+                    "key_phrases": ["핵심", "키워드", "..."],
+                },
+            },
         },
+        image_files=None,
     )
-    # 중립 추론 케이스
-    await client.post(
-        "/diaries",
-        json={
+    # 중립
+    await _post_diary_multipart(
+        client,
+        {
             "user_id": user_id,
             "title": "emo3",
             "content": "c3",
-            "emotion_analysis": {"positive": 0.2, "negative": 0.2, "neutral": 0.6},
+            "emotion_analysis_report": {
+                "main_emotion": "중립",
+                "confidence": 1.0,
+                "emotion_analysis": {
+                    "reason": "감정 판단의 근거 텍스트",
+                    "key_phrases": ["핵심", "키워드", "..."],
+                },
+            },
         },
+        image_files=None,
     )
 
-    res = await client.get(
-        "/diaries/stats/summary", params={"user_id": user_id, "inferred": True}
-    )
-    assert res.status_code == 200
-    stats = res.json()["items"]
-
-    # 최소한 세 감정이 각각 1개 이상 카운트 되는지 확인
-    assert stats.get("긍정", 0) >= 1
-    assert stats.get("부정", 0) >= 1
-    assert stats.get("중립", 0) >= 1
+    res = await client.get("/diaries/stats/summary", params={"user_id": user_id})
+    assert res.status_code == 200, res.text
+    stats = res.json().get("items") or {}
+    assert stats.get("긍정", 1) >= 1
+    assert stats.get("부정", 1) >= 1
+    assert stats.get("중립", 1) >= 1

--- a/app/diary/test_diary.py
+++ b/app/diary/test_diary.py
@@ -17,7 +17,6 @@ from tortoise import Tortoise
 
 from app.ai.schema import DiaryEmotionResponse, EmotionAnalysis
 from app.diary.api import router as diary_router
-from app.diary.service import _resolve_ai
 from app.user.model import User
 
 # pytest-asyncio 만 사용
@@ -104,7 +103,7 @@ async def client(app: FastAPI):
     - httpx AsyncClient 구성
     """
     # 테스트에서만 AI 의존성 오버라이드
-    app.dependency_overrides[_resolve_ai] = lambda: _StubAI()
+    # app.dependency_overrides[_resolve_ai] = lambda: _StubAI()
 
     # ORM 초기화(테스트 모델 등록)
     #   - Tag 모델이 app.diary.model 안으로 통합됐다면 "app.tag.model" 항목을 제거하세요.

--- a/app/files/api.py
+++ b/app/files/api.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+
+from app.files.schema import UploadImageOptions, UploadImageResponse
+from app.files.service import CloudinaryService
+
+router = APIRouter(prefix="/files", tags=["Files"])
+
+
+# -------------------------------
+# 이미지 업로드 (Cloudinary)
+# -------------------------------
+@router.post(
+    "/images",
+    response_model=UploadImageResponse,
+    summary="이미지 업로드(Cloudinary)",
+)
+async def upload_image(
+    file: UploadFile = File(..., description="업로드할 이미지"),
+    folder: str | None = Query(
+        None, description="Cloudinary 폴더(미지정 시 기본값 사용)"
+    ),
+    width: int | None = Query(None, ge=1, description="리사이즈 가로"),
+    height: int | None = Query(None, ge=1, description="리사이즈 세로"),
+    crop: str | None = Query(None, description="자르기 모드(scale/fill/fit/limit 등)"),
+    quality: str | None = Query(None, description="품질(auto 또는 1~100)"),
+):
+    """
+    - 이미지 업로드 후 Cloudinary URL 반환
+    - 필요 시 폴더/리사이즈/자르기/품질 옵션 지정 가능(모두 선택)
+    """
+    opts = UploadImageOptions(
+        folder=folder,
+        width=width,
+        height=height,
+        crop=crop,
+        quality=quality,
+    )
+    return await CloudinaryService.upload_image(file, opts=opts)
+
+
+# -------------------------------
+# 이미지 삭제 (옵션)
+# -------------------------------
+@router.delete(
+    "/images/{public_id}",
+    summary="Cloudinary 이미지 삭제(옵션)",
+)
+async def delete_image(public_id: str):
+    ok = await CloudinaryService.delete_image(public_id)
+    if not ok:
+        # 이미 삭제되었거나 없음
+        raise HTTPException(status_code=404, detail="이미 존재하지 않는 이미지")
+    return {"deleted": True}

--- a/app/files/schema.py
+++ b/app/files/schema.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+# 업로드 옵션(선택): 변환/폴더 등
+class UploadImageOptions(BaseModel):
+    # Cloudinary 폴더 경로 (예: myapp/diary)
+    folder: Optional[str] = Field(default=None, description="업로드 폴더")
+    # 가로/세로 리사이즈(선택)
+    width: Optional[int] = Field(default=None, ge=1, description="리사이즈 가로(px)")
+    height: Optional[int] = Field(default=None, ge=1, description="리사이즈 세로(px)")
+    # 자르기 모드(예: 'scale', 'fill', 'fit', 'limit' 등)
+    crop: Optional[str] = Field(default=None, description="자르기 모드")
+    # 품질(예: 'auto' 또는 1~100)
+    quality: Optional[str] = Field(default=None, description="이미지 품질")
+
+
+class UploadImageResponse(BaseModel):
+    # Cloudinary 결과(필요한 핵심만 노출)
+    public_id: str
+    url: str
+    secure_url: str
+    width: int
+    height: int
+    format: str
+    bytes: int

--- a/app/files/service.py
+++ b/app/files/service.py
@@ -1,0 +1,218 @@
+import os
+import uuid
+from functools import partial
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import anyio
+import cloudinary  # type: ignore[import-untyped]
+import cloudinary.uploader as cu  # type: ignore[import-untyped]
+from fastapi import HTTPException, UploadFile
+
+from app.files.schema import UploadImageOptions, UploadImageResponse
+
+# ------------------------------------------------------------
+# Cloudinary 기본 설정 (앱 시작 시 1회 설정)
+# ------------------------------------------------------------
+cloudinary.config(
+    cloud_name=os.getenv("CLOUDINARY_CLOUD_NAME"),
+    api_key=os.getenv("CLOUDINARY_API_KEY"),
+    api_secret=os.getenv("CLOUDINARY_API_SECRET"),
+    secure=True,
+)
+
+# 허용 확장자/타입
+ALLOWED_TYPES: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+# 사이즈/개수 제한
+MAX_SIZE_MB: float = float(os.getenv("CLOUDINARY_MAX_SIZE_MB", "5"))
+MAX_BYTES: int = int(MAX_SIZE_MB * 1024 * 1024)
+MAX_IMAGE_FILES: int = int(os.getenv("CLOUDINARY_MAX_FILES", "10"))
+
+
+def _build_transformations(opts: UploadImageOptions | None) -> Dict[str, Any]:
+    """
+    Cloudinary에 전달할 변환/옵션 파라미터 구성.
+    - 지정된 값만 포함(불필요 파라미터 제외)
+    """
+    params: Dict[str, Any] = {}
+    if not opts:
+        # 기본값 추천: 자동 포맷/퀄리티
+        params["fetch_format"] = "auto"
+        params["quality"] = "auto"
+        return params
+
+    if opts.folder:
+        params["folder"] = opts.folder
+    if opts.width:
+        params["width"] = opts.width
+    if opts.height:
+        params["height"] = opts.height
+    if opts.crop:
+        params["crop"] = opts.crop
+    if opts.quality:
+        params["quality"] = opts.quality
+
+    # 기본값(없으면 설정)
+    params.setdefault("fetch_format", "auto")
+    params.setdefault("quality", "auto")
+    return params
+
+
+def _unique_preserve_order(values: Sequence[str]) -> List[str]:
+    out: List[str] = []
+    seen: set[str] = set()
+    for v in values:
+        s = (v or "").strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+class CloudinaryService:
+    # ============== 업로드 ==============
+    @staticmethod
+    async def upload_image(
+        file: UploadFile,
+        opts: Optional[UploadImageOptions] = None,
+    ) -> UploadImageResponse:
+        # 1) MIME 검증
+        if file.content_type not in ALLOWED_TYPES:
+            raise HTTPException(
+                status_code=415, detail="이미지 형식만 허용합니다 (jpg/png/webp/gif)"
+            )
+
+        # 2) 크기 제한
+        data = await file.read()
+        if len(data) > MAX_BYTES:
+            raise HTTPException(
+                status_code=413, detail=f"파일이 너무 큽니다(최대 {int(MAX_SIZE_MB)}MB)"
+            )
+
+        # 3) 업로드 파라미터 준비
+        params = _build_transformations(opts)
+        params["public_id"] = uuid.uuid4().hex  # 명시적 public_id
+
+        # 4) 동기 SDK → 스레드 오프로딩 (kwargs는 partial로 래핑)
+        upload_call = partial(
+            cu.upload,
+            data,
+            resource_type="image",
+            **params,
+        )
+
+        try:
+            res: dict[str, Any] = await anyio.to_thread.run_sync(upload_call)
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=f"업로드 실패: {e}")
+
+        # 5) 결과 매핑
+        try:
+            return UploadImageResponse(
+                public_id=str(res["public_id"]),
+                url=str(res["url"]),
+                secure_url=str(res["secure_url"]),
+                width=int(res["width"]),
+                height=int(res["height"]),
+                format=str(res["format"]),
+                bytes=int(res["bytes"]),
+            )
+        except KeyError as ke:
+            raise HTTPException(
+                status_code=502, detail=f"업로드 응답 파싱 오류: 누락된 키 {ke!s}"
+            )
+
+    @staticmethod
+    async def upload_images(
+        files: Sequence[UploadFile] | None,
+        opts: Optional[UploadImageOptions] = None,
+    ) -> List[UploadImageResponse]:
+        """
+        파일 0~N개 동시 업로드.
+        - 순서를 보존
+        - 실패는 건너뛰고 성공만 반환
+        """
+        if not files:
+            return []
+        if len(files) > MAX_IMAGE_FILES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"이미지 최대 {MAX_IMAGE_FILES}개까지 업로드 가능합니다.",
+            )
+
+        import asyncio
+
+        results: List[Union[UploadImageResponse, BaseException]] = await asyncio.gather(
+            *(CloudinaryService.upload_image(f, opts) for f in files),
+            return_exceptions=True,
+        )
+
+        out: List[UploadImageResponse] = []
+        for r in results:
+            if isinstance(r, BaseException):
+                # TODO: 로깅/알림 등
+                continue
+            out.append(r)
+        return out
+
+    @staticmethod
+    async def upload_images_to_urls(
+        files: Sequence[UploadFile] | None,
+        opts: Optional[UploadImageOptions] = None,
+    ) -> List[str]:
+        """
+        파일 0~N개 업로드 → secure_url 리스트 반환(순서 보존, 중복 제거)
+        """
+        responses = await CloudinaryService.upload_images(files, opts)
+        urls = [r.secure_url for r in responses]
+        return _unique_preserve_order(urls)
+
+    # ============== 삭제 ==============
+    @staticmethod
+    async def delete_image(public_id: str, invalidate: bool = True) -> bool:
+        """
+        업로드된 이미지를 Cloudinary에서 삭제
+        - invalidate=True: CDN 무효화
+        """
+        destroy_call = partial(
+            cu.destroy,
+            public_id,
+            invalidate=invalidate,
+            resource_type="image",
+        )
+        try:
+            res: dict[str, Any] = await anyio.to_thread.run_sync(destroy_call)
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=f"삭제 실패: {e}")
+
+        # res 예: {"result": "ok"} / {"result": "not found"}
+        return res.get("result") == "ok"
+
+    @staticmethod
+    async def delete_images(
+        public_ids: Sequence[str], invalidate: bool = True
+    ) -> dict[str, bool]:
+        """
+        다중 삭제: 각 public_id별 성공 여부를 반환
+        """
+        if not public_ids:
+            return {}
+        import asyncio
+
+        results = await asyncio.gather(
+            *(
+                CloudinaryService.delete_image(pid, invalidate=invalidate)
+                for pid in public_ids
+            ),
+            return_exceptions=True,
+        )
+        out: dict[str, bool] = {}
+        for pid, r in zip(public_ids, results):
+            out[pid] = False if isinstance(r, BaseException) else bool(r)
+        return out

--- a/app/notification/service.py
+++ b/app/notification/service.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, time
 
-from app.diary.model import MainEmotion
+from app.diary.model import MainEmotionType
 from app.notification.model import NotificationType
 from app.notification.repository import create_notification
 from app.user.model import EmotionStats, PeriodType, User
@@ -21,7 +21,7 @@ async def check_weekly_negative_emotions(user_id: int) -> bool:
         period_type=PeriodType.WEEKLY.value,
         created_at__gte=start,
         created_at__lt=end,
-        emotion_type=MainEmotion.NEGATIVE.value,
+        emotion_type=MainEmotionType.NEGATIVE.value,
     )
     return stats is not None and stats.frequency >= 5
 

--- a/app/notification/test_notification.py
+++ b/app/notification/test_notification.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from tortoise import Tortoise
 
-from app.diary.model import MainEmotion
+from app.diary.model import MainEmotionType
 from app.notification.api import router as notification_router
 from app.notification.service import send_notifications
 from app.user.model import EmotionStats, NotificationType, PeriodType, User
@@ -73,8 +73,8 @@ async def test_emotionstat(test_user: User) -> AsyncGenerator[EmotionStats, None
     emotionstat = await EmotionStats.create(
         user_id=test_user.id,
         period_type=PeriodType.WEEKLY.value,
-        emotion_type=MainEmotion.NEGATIVE.value,
-        type=MainEmotion.NEGATIVE,
+        emotion_type=MainEmotionType.NEGATIVE.value,
+        type=MainEmotionType.NEGATIVE,
         frequency=5,
     )
     yield emotionstat

--- a/app/tag/model.py
+++ b/app/tag/model.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from tortoise import fields
 from tortoise.models import Model
 
 if TYPE_CHECKING:
-    from app.diary.model import Diary  # 실제 Diary 모델이 정의된 경로에 맞춰 수정
+    from app.diary.model import Diary  # 실제 Tag 모델이 정의된 경로에 맞춰 수정
 
 
 class Tag(Model):
-    tag_id = fields.BigIntField(pk=True, generated=True)  # 태그 ID, AUTO_INCREMENT
-    tag_name = fields.CharField(max_length=50, unique=True)
-
+    id = fields.IntField(pk=True, generated=True)
+    name = fields.CharField(max_length=50, unique=True)
     diaries: fields.ManyToManyRelation["Diary"]
 
     class Meta:

--- a/app/user/model.py
+++ b/app/user/model.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from tortoise import Model, fields
 
-from app.diary.model import MainEmotion
+from app.diary.model import MainEmotionType
 from app.notification.model import NotificationType
 from app.shared.model import TimestampMixin
 
@@ -56,7 +56,7 @@ class EmotionStats(Model):
         "models.User", related_name="emotion_stats"
     )  # FK
     period_type = fields.CharEnumField(PeriodType)  # ENUM
-    emotion_type = fields.CharEnumField(MainEmotion)  # ENUM
+    emotion_type = fields.CharEnumField(MainEmotionType)  # ENUM
     frequency = fields.IntField()  # 횟수
     created_at = fields.DatetimeField(auto_now_add=True)  # 생성시 자동 입력
 

--- a/core/config.py
+++ b/core/config.py
@@ -1,27 +1,75 @@
+from __future__ import annotations
+
 import os
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
 
 TORTOISE_ORM = {
     "connections": {"default": "postgres://diaryapi:diaryapi@db:5432/diaryapi"},
     "apps": {
         "models": {
             "models": [
-                "app.diary.model",  # 다이어리 관련 모델
-                "app.user.model",  # 유저 관련 모델
-                "app.tag.model",  # 결제 관련 모델
+                "app.diary.model",
+                "app.user.model",
+                "app.tag.model",
                 "app.notification.model",
-                "aerich.models",  # 꼭 포함해야 함
+                "aerich.models",
             ],
             "default_connection": "default",
         },
     },
 }
 
-AI_SETTINGS = {
-    "google_api_key": os.getenv("GOOGLE_API_KEY"),
-    "model_name": os.getenv("AI_MODEL_NAME", "gemini-1.5-flash"),
-    "max_tokens": int(os.getenv("AI_MAX_TOKENS", "1000")),
-    "temperature": float(os.getenv("AI_TEMPERATURE", "0.7")),
-}
 
-if not AI_SETTINGS["google_api_key"]:
-    raise ValueError("GOOGLE_API_KEY 환경 변수가 설정되지 않았습니다.")
+# ── helpers ───────────────────────────────────────────────────────
+def _getenv_int(name: str, default: int) -> int:
+    v = os.getenv(name)
+    try:
+        return int(v) if v is not None else default
+    except ValueError:
+        return default
+
+
+def _getenv_float(name: str, default: float) -> float:
+    v = os.getenv(name)
+    try:
+        return float(v) if v is not None else default
+    except ValueError:
+        return default
+
+
+# ── AI (typed + legacy 호환) ─────────────────────────────────────
+@dataclass(frozen=True)
+class AISettings:
+    google_api_key: str | None
+    model_name: str
+    max_tokens: int
+    temperature: float
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.google_api_key)
+
+
+def load_ai_settings() -> AISettings:
+    return AISettings(
+        google_api_key=os.getenv("GOOGLE_API_KEY") or None,
+        model_name=os.getenv("AI_MODEL_NAME", "gemini-2.5-flash"),
+        max_tokens=_getenv_int("AI_MAX_TOKENS", 1000),
+        temperature=_getenv_float("AI_TEMPERATURE", 0.7),
+    )
+
+
+AI_SETTINGS_OBJ: AISettings = load_ai_settings()
+AI_ENABLED: bool = AI_SETTINGS_OBJ.enabled
+
+# 레거시 dict 접근 호환 (읽기 전용)
+AI_SETTINGS: Mapping[str, object] = MappingProxyType(
+    {
+        "google_api_key": AI_SETTINGS_OBJ.google_api_key,
+        "model_name": AI_SETTINGS_OBJ.model_name,
+        "max_tokens": AI_SETTINGS_OBJ.max_tokens,
+        "temperature": AI_SETTINGS_OBJ.temperature,
+    }
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "aerich==0.9.1",
     "anyio>=4.10.0",
     "asyncpg==0.30.0",
+    "cloudinary>=1.44.1",
     "coverage==7.10.5",
     "fastapi==0.116.1",
     "google-generativeai>=0.8.5",
@@ -18,6 +19,7 @@ dependencies = [
     "pytest-cov>=6.2.1",
     "pytest-mock>=3.14.1",
     "python-dotenv==1.1.1",
+    "python-multipart>=0.0.20",
     "tortoise-orm==0.25.1",
     "uvicorn==0.35.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudinary"
+version = "1.44.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/35/938a4cc3b5ac386184a8ea50e357cdbb4239c2744fc8c652c461674447e6/cloudinary-1.44.1.tar.gz", hash = "sha256:62d4374b79d5476de2a86cb6a1da709a5429e02aef474bfc5d99f3e38a1a62ff", size = 188225, upload-time = "2025-06-17T16:31:33.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/f0/518d151d3dfc009940947fe9b26cdf9f6e2fb9e4a29c12fe5b5ebe8aad65/cloudinary-1.44.1-py3-none-any.whl", hash = "sha256:b4785031179a5ec7010f46665e5c8fad2cae022c18405546f01d257e02f78b1c", size = 147808, upload-time = "2025-06-17T16:31:32.188Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +332,7 @@ dependencies = [
     { name = "aerich" },
     { name = "anyio" },
     { name = "asyncpg" },
+    { name = "cloudinary" },
     { name = "coverage" },
     { name = "fastapi" },
     { name = "google-generativeai" },
@@ -328,6 +343,7 @@ dependencies = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "tortoise-orm" },
     { name = "uvicorn" },
 ]
@@ -350,6 +366,7 @@ requires-dist = [
     { name = "aerich", specifier = "==0.9.1" },
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "asyncpg", specifier = "==0.30.0" },
+    { name = "cloudinary", specifier = ">=1.44.1" },
     { name = "coverage", specifier = "==7.10.5" },
     { name = "fastapi", specifier = "==0.116.1" },
     { name = "google-generativeai", specifier = ">=0.8.5" },
@@ -360,6 +377,7 @@ requires-dist = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "python-dotenv", specifier = "==1.1.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "tortoise-orm", specifier = "==0.25.1" },
     { name = "uvicorn", specifier = "==0.35.0" },
 ]
@@ -970,6 +988,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1055,6 +1082,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/d4/1aaa7fb201a74181989970ebccd12f88c0fc074777027e2a21de5a90657e/ruff-0.12.10-py3-none-win32.whl", hash = "sha256:9de785e95dc2f09846c5e6e1d3a3d32ecd0b283a979898ad427a9be7be22b266", size = 11896089, upload-time = "2025-08-21T18:23:14.232Z" },
     { url = "https://files.pythonhosted.org/packages/ad/14/2ad38fd4037daab9e023456a4a40ed0154e9971f8d6aed41bdea390aabd9/ruff-0.12.10-py3-none-win_amd64.whl", hash = "sha256:7837eca8787f076f67aba2ca559cefd9c5cbc3a9852fd66186f4201b87c1563e", size = 13004616, upload-time = "2025-08-21T18:23:17.422Z" },
     { url = "https://files.pythonhosted.org/packages/24/3c/21cf283d67af33a8e6ed242396863af195a8a6134ec581524fd22b9811b6/ruff-0.12.10-py3-none-win_arm64.whl", hash = "sha256:cc138cc06ed9d4bfa9d667a65af7172b47840e1a98b02ce7011c391e54635ffc", size = 12074225, upload-time = "2025-08-21T18:23:20.137Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## ✨ 변경 사항
일간, 주간 감정 통계를 낼 수 있는 API 기능 추가

다이어리 디렉토리에 감정통계 기능 추가함

1) model.py api.py, service.py 추가
2) schema.py repository.py 추가
3) 테스트 코드는 아직 작성 중


## 📝 기타 (선택)
상환님의 ai 모델에서 제 diary의 main emotion type class (긍정, 부정, 중립 정의) 를 참조하고 있게 수정되었는데
저는 상환님껄 참조하고 있어서 diary의 클래스를 기준으로 참조 하게  수정하였습니다.
